### PR TITLE
Remove HTML file in favor of plain text response

### DIFF
--- a/auto_quit.html
+++ b/auto_quit.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html>
-
-<body>Success! You can now close this window !</body>
-
-</html>

--- a/src/token_retrieval/mod.rs
+++ b/src/token_retrieval/mod.rs
@@ -42,7 +42,7 @@ pub fn retrieve_tokens(handle: &mut EasyAPI) -> Result<(), std::io::Error> {
             println!("token {}", code.as_str());
 
             // TODO, store the value for the other thread
-            let response = tiny_http::Response::from_file(File::open("auto_quit.html").unwrap());
+            let response = tiny_http::Response::from_string("Success! You can now close this window!");
             let _ = request.respond(response);
             break;
         }

--- a/src/token_retrieval/mod.rs
+++ b/src/token_retrieval/mod.rs
@@ -42,7 +42,7 @@ pub fn retrieve_tokens(handle: &mut EasyAPI) -> Result<(), std::io::Error> {
             println!("token {}", code.as_str());
 
             // TODO, store the value for the other thread
-            let response = tiny_http::Response::from_string("Success! You can now close this window!");
+            let response = tiny_http::Response::from_string("Success! You can now close this window!".to_string());
             let _ = request.respond(response);
             break;
         }


### PR DESCRIPTION
Having an HTML at the root of the repo looks messy IMHO.