### PR TITLE
Remove unused dependency

### DIFF
--- a/spotify_api/Cargo.toml
+++ b/spotify_api/Cargo.toml
@@ -9,4 +9,3 @@ authors = ["Julien LE THENO"]
 curl = "0.4.18"
 serde_json = "1.0"
 percent-encoding = "1.0.1"
-failure = "0.1"

--- a/spotify_api/src/lib.rs
+++ b/spotify_api/src/lib.rs
@@ -3,7 +3,6 @@
     @mod EasyAPI : handles the whole Spotify API bindings,
     and the API rights
 */
-extern crate failure;
 extern crate serde_json;
 
 mod command;


### PR DESCRIPTION
`failure` is not used in `spotify_api`.